### PR TITLE
Add translation-aware speech handling

### DIFF
--- a/Server/Localization/TranslationService.cs
+++ b/Server/Localization/TranslationService.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Server.Localization
+{
+    /// <summary>
+    /// Provides translation utilities for converting player speech into the server's base language.
+    /// Currently this is a stub that returns the original text.
+    /// </summary>
+    public static class TranslationService
+    {
+        /// <summary>
+        /// Translate text from the player's language to the server's default language.
+        /// </summary>
+        /// <param name="text">The player's original speech.</param>
+        /// <returns>The translated text suitable for server processing.</returns>
+        public static string TranslateToServerLanguage(string text)
+        {
+            return text;
+        }
+    }
+}

--- a/Server/Mobile.cs
+++ b/Server/Mobile.cs
@@ -4846,12 +4846,12 @@ namespace Server
 		private static List<Mobile> m_Hears = new List<Mobile>();
 		private static List<IEntity> m_OnSpeech = new List<IEntity>();
 
-		public virtual void DoSpeech( string text, int[] keywords, MessageType type, int hue )
-		{
-			if( m_Deleted || CommandSystem.Handle( this, text, type ) )
-				return;
+                public virtual void DoSpeech( string serverText, int[] keywords, MessageType type, int hue, string displayText = null )
+                {
+                        if( m_Deleted || CommandSystem.Handle( this, serverText, type ) )
+                                return;
 
-			int range = 15;
+                        int range = 15;
 
 			switch( type )
 			{
@@ -4874,7 +4874,7 @@ namespace Server
 					break;
 			}
 
-			SpeechEventArgs regArgs = new SpeechEventArgs( this, text, type, hue, keywords );
+                        SpeechEventArgs regArgs = new SpeechEventArgs( this, serverText, type, hue, keywords );
 
 			EventSink.InvokeSpeech( regArgs );
 			this.Region.OnSpeech( regArgs );
@@ -4883,10 +4883,13 @@ namespace Server
 			if( regArgs.Blocked )
 				return;
 
-			text = regArgs.Speech;
+                        serverText = regArgs.Speech;
 
-			if( string.IsNullOrEmpty( text ) )
-				return;
+                        if( string.IsNullOrEmpty( serverText ) )
+                                return;
+
+                        if( displayText == null )
+                                displayText = serverText;
 
 
 			List<Mobile> hears = m_Hears;
@@ -4932,9 +4935,9 @@ namespace Server
 
 				eable.Free();
 
-				object mutateContext = null;
-				string mutatedText = text;
-				SpeechEventArgs mutatedArgs = null;
+                                object mutateContext = null;
+                                string mutatedText = serverText;
+                                SpeechEventArgs mutatedArgs = null;
 
 				if( MutateSpeech( hears, ref mutatedText, ref mutateContext ) )
 					mutatedArgs = new SpeechEventArgs( this, mutatedText, type, hue, new int[0] );
@@ -4951,29 +4954,29 @@ namespace Server
 				for( int i = 0; i < hears.Count; ++i ) {
 					Mobile heard = hears[i];
 
-					if( mutatedArgs == null || !CheckHearsMutatedSpeech( heard, mutateContext ) ) {
-						heard.OnSpeech( regArgs );
+                                        if( mutatedArgs == null || !CheckHearsMutatedSpeech( heard, mutateContext ) ) {
+                                                heard.OnSpeech( regArgs );
 
-						NetState ns = heard.NetState;
+                                                NetState ns = heard.NetState;
 
-						if( ns != null ) {
-							if( regp == null )
-								regp = Packet.Acquire( new UnicodeMessage( m_Serial, Body, type, hue, 3, m_Language, Name, text ) );
+                                                if( ns != null ) {
+                                                        if( regp == null )
+                                                                regp = Packet.Acquire( new UnicodeMessage( m_Serial, Body, type, hue, 3, m_Language, Name, displayText ) );
 
-							ns.Send( regp );
-						}
-					} else {
-						heard.OnSpeech( mutatedArgs );
+                                                        ns.Send( regp );
+                                                }
+                                        } else {
+                                                heard.OnSpeech( mutatedArgs );
 
-						NetState ns = heard.NetState;
+                                                NetState ns = heard.NetState;
 
-						if( ns != null ) {
-							if( mutp == null )
-								mutp = Packet.Acquire( new UnicodeMessage( m_Serial, Body, type, hue, 3, m_Language, Name, mutatedText ) );
+                                                if( ns != null ) {
+                                                        if( mutp == null )
+                                                                mutp = Packet.Acquire( new UnicodeMessage( m_Serial, Body, type, hue, 3, m_Language, Name, mutatedText ) );
 
-							ns.Send( mutp );
-						}
-					}
+                                                        ns.Send( mutp );
+                                                }
+                                        }
 				}
 
 				Packet.Release( regp );

--- a/Server/Network/PacketHandlers.cs
+++ b/Server/Network/PacketHandlers.cs
@@ -34,6 +34,7 @@ using Server.Prompts;
 using Server.HuePickers;
 using Server.ContextMenus;
 using Server.Diagnostics;
+using Server.Localization;
 using CV = Server.ClientVersion;
 
 namespace Server.Network
@@ -1384,16 +1385,19 @@ namespace Server.Network
 			MessageType type = (MessageType)pvSrc.ReadByte();
 			int hue = pvSrc.ReadInt16();
 			pvSrc.ReadInt16(); // font
-			string text = pvSrc.ReadStringSafe().Trim();
+                        string text = pvSrc.ReadStringSafe().Trim();
 
-			if ( text.Length <= 0 || text.Length > 128 )
-				return;
+                        if ( text.Length <= 0 || text.Length > 128 )
+                                return;
 
-			if ( !Enum.IsDefined( typeof( MessageType ), type ) )
-				type = MessageType.Regular;
+                        if ( !Enum.IsDefined( typeof( MessageType ), type ) )
+                                type = MessageType.Regular;
 
-			from.DoSpeech( text, m_EmptyInts, type, Utility.ClipDyedHue( hue ) );
-		}
+                        string displayText = text;
+                        string serverText = TranslationService.TranslateToServerLanguage( displayText );
+
+                        from.DoSpeech( serverText, m_EmptyInts, type, Utility.ClipDyedHue( hue ), displayText );
+                }
 
 		private static KeywordList m_KeywordList = new KeywordList();
 
@@ -1464,9 +1468,13 @@ namespace Server.Network
 			if ( !Enum.IsDefined( typeof( MessageType ), type ) )
 				type = MessageType.Regular;
 
-			from.Language = lang;
-			from.DoSpeech( text, keywords, type, Utility.ClipDyedHue( hue ) );
-		}
+                        from.Language = lang;
+
+                        string displayText = text;
+                        string serverText = TranslationService.TranslateToServerLanguage( displayText );
+
+                        from.DoSpeech( serverText, keywords, type, Utility.ClipDyedHue( hue ), displayText );
+                }
 
 		public static void UseReq( NetState state, PacketReader pvSrc )
 		{


### PR DESCRIPTION
## Summary
- translate incoming speech using a placeholder service before server processing
- preserve original player speech for display while using translated text for commands and checks
- introduce stub `TranslationService` ready for future localization work

## Testing
- `dotnet build Server/Server.csproj` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package dotnet-sdk-8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a635d1b4c8832e97c3e1ee61c8cb18