### PR TITLE
Add basic translation service using Google API

### DIFF
--- a/Server/Localization/TranslationService.cs
+++ b/Server/Localization/TranslationService.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Net;
+using System.Text.RegularExpressions;
 
 namespace Server.Localization
 {
@@ -8,6 +10,8 @@ namespace Server.Localization
     /// </summary>
     public static class TranslationService
     {
+        private const string TargetLanguage = "es";
+
         /// <summary>
         /// Translate text from the player's language to the server's default language.
         /// </summary>
@@ -15,6 +19,43 @@ namespace Server.Localization
         /// <returns>The translated text suitable for server processing.</returns>
         public static string TranslateToServerLanguage(string text)
         {
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                return text;
+            }
+
+            try
+            {
+                var url = $"https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl={TargetLanguage}&dt=t&q={Uri.EscapeDataString(text)}";
+
+                using (var client = new WebClient())
+                {
+                    client.Headers.Add("User-Agent", "Mozilla/5.0");
+
+                    var response = client.DownloadString(url);
+
+                    // Response format: [[[\"Hola Mundo\",\"Hello world\",null,null,10]],null,\"en\",...]
+                    var translationMatch = Regex.Match(response, "\\[\\[\\[\"(?<translated>.+?)\"");
+                    var languageMatch = Regex.Match(response, "\\],null,\"(?<lang>[^\"]+)\"");
+
+                    if (translationMatch.Success)
+                    {
+                        var translated = translationMatch.Groups["translated"].Value;
+
+                        if (languageMatch.Success && languageMatch.Groups["lang"].Value.StartsWith(TargetLanguage, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return text; // Already in target language
+                        }
+
+                        return translated;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine($"Translation error: {e.Message}");
+            }
+
             return text;
         }
     }


### PR DESCRIPTION
## Summary
- add translation service calling Google Translate for speech
- detect language and convert non-Spanish speech to Spanish before handling

## Testing
- `mono /tmp/test_translation.exe`
- `mono /tmp/test_dospeech.exe`


------
https://chatgpt.com/codex/tasks/task_e_68a648302810832e90657b5b5c43280c