### PR TITLE
Traduce textos de gumps y mensajes de validación

### DIFF
--- a/Scripts/Engines and systems/Animal Broker system/Rewards/SarcoNameGump.cs
+++ b/Scripts/Engines and systems/Animal Broker system/Rewards/SarcoNameGump.cs
@@ -10,7 +10,7 @@ namespace Server.Gumps
 {
     public class SarcoNameGump : Gump
     {
-        const string DEFAULT_NAME = "Type here...";
+        const string DEFAULT_NAME = "Escribe aquí...";
         private Item m_gate;
 
         public SarcoNameGump(Mobile from, Item gate) : base(100, 100)
@@ -27,7 +27,7 @@ namespace Server.Gumps
             AddBackground(221, 264, 171, 29, 3000);
             AddHtml(153, 135, 304, 113, @"Enter a name for this sarcophagus below.", (bool)true, (bool)false);
 
-            AddLabel(153, 270, 0, @"New Name:");
+            AddLabel(153, 270, 0, @"Nuevo nombre:");
             AddTextEntry(224, 268, 163, 21, 0, 1, DEFAULT_NAME, 16); // 16 Character Limit
             AddButton(395, 267, 4023, 4024, 1, GumpButtonType.Reply, 0); // Okay
         }

--- a/Scripts/Items and addons/Containers/ContainerNameGump.cs
+++ b/Scripts/Items and addons/Containers/ContainerNameGump.cs
@@ -10,7 +10,7 @@ namespace Server.Gumps
 {
     public class ContainerNameGump : Gump
     {
-        const string DEFAULT_NAME = "Type here...";
+        const string DEFAULT_NAME = "Escribe aquí...";
         private BaseContainer m_gate;
 
         public ContainerNameGump(Mobile from, BaseContainer gate) : base(100, 100)
@@ -28,7 +28,7 @@ namespace Server.Gumps
 			AddHtml(153, 170, 304, 113, @"The name will be overwritten!", (bool)true, (bool)false);
 
             AddBackground(221, 285, 171, 29, 3000);
-            AddLabel(153, 290, 0, @"New Name:");
+            AddLabel(153, 290, 0, @"Nuevo nombre:");
             AddTextEntry(224, 290, 163, 21, 0, 1, DEFAULT_NAME, 16); // 16 Character Limit
             AddButton(395, 290, 4023, 4024, 1, GumpButtonType.Reply, 0); // Okay
         }

--- a/Scripts/Items and addons/Linked Gates/GateNameGump.cs
+++ b/Scripts/Items and addons/Linked Gates/GateNameGump.cs
@@ -11,7 +11,7 @@ namespace Server.Gumps
 {
     public class GateNameGump : Gump
     {
-        const string DEFAULT_NAME = "Type here...";
+        const string DEFAULT_NAME = "Escribe aquí...";
         private LinkedGate m_gate;
 
         public GateNameGump(Mobile from, LinkedGate gate) : base(100, 100)
@@ -28,7 +28,7 @@ namespace Server.Gumps
             AddHtml(153, 135, 304, 113, @"Enter a name for this gate below.", (bool)true, (bool)false);
             AddBackground(221, 264, 171, 29, 3000);
 
-            AddLabel(153, 270, 0, @"New Name:");
+            AddLabel(153, 270, 0, @"Nuevo nombre:");
             AddTextEntry(224, 268, 163, 21, 0, 1, DEFAULT_NAME, 16); // 16 Character Limit
             AddButton(395, 267, 4023, 4024, 1, GumpButtonType.Reply, 0); // Okay
         }

--- a/Scripts/Server Functions/Unique Name/CensusRecords.cs
+++ b/Scripts/Server Functions/Unique Name/CensusRecords.cs
@@ -49,7 +49,7 @@ namespace Server.Gumps
 {
     public class CensusGump : Gump
     {
-        const string DEFAULT_NAME = "Type here...";
+        const string DEFAULT_NAME = "Escribe aquí...";
         public CensusGump(Mobile from, bool legal) : base(25, 25)
         {
             this.Closable=true;
@@ -104,12 +104,12 @@ namespace Server.Gumps
             {
                 if (!NameVerification.Validate(name, 2, 16, true, false, true, 1, NameVerification.SpaceOnly))
                 {
-                    from.SendMessage(0X22, "That name is unacceptable or already taken.");
+                    from.SendMessage(0X22, "Ese nombre no es aceptable o ya está en uso.");
                     return;
                 }
                 else if ( CharacterCreation.CheckDupe(from, name) && pack.ConsumeTotal(typeof(Gold), 2000) )
                 {
-                    from.SendMessage(0X22, "Your name is now {0}.", name);
+                    from.SendMessage(0X22, "Tu nombre ahora es {0}.", name);
                     from.Name = name;
                     from.CantWalk = false;
                     return;
@@ -121,13 +121,13 @@ namespace Server.Gumps
                 }
                 else
                 {
-                    from.SendMessage(0X22, "That name is unacceptable or already taken.");
+                    from.SendMessage(0X22, "Ese nombre no es aceptable o ya está en uso.");
                     return;
                 }
             }
             else
             {
-                from.SendMessage(0X22, "You must enter a name.");
+                from.SendMessage(0X22, "Debes introducir un nombre.");
             }
         }
     }

--- a/Scripts/Server Functions/Unique Name/NameAlterGump.cs
+++ b/Scripts/Server Functions/Unique Name/NameAlterGump.cs
@@ -9,7 +9,7 @@ namespace Server.Gumps
 {
     public class NameAlterGump : Gump
     {
-        const string DEFAULT_NAME = "Type here...";
+        const string DEFAULT_NAME = "Escribe aquí...";
         public NameAlterGump(Mobile from) : base(25, 25)
         {
             this.Closable=true;
@@ -58,23 +58,23 @@ namespace Server.Gumps
             {
                 if (!NameVerification.Validate(name, 2, 16, true, false, true, 1, NameVerification.SpaceOnly))
                 {
-                    from.SendMessage(0X22, "That name is unacceptable or already taken.");
+                    from.SendMessage(0X22, "Ese nombre no es aceptable o ya está en uso.");
                 }
                 else if ( CharacterCreation.CheckDupe(from, name) )
                 {
-                    from.SendMessage(0X22, "Your name is now {0}.", name);
+                    from.SendMessage(0X22, "Tu nombre ahora es {0}.", name);
                     from.Name = name;
                     from.CantWalk = false;
                     return;
                 }
                 else if ( CharacterCreation.CheckDupe(from, name) )
                 {
-                    from.SendMessage(0X22, "That name is unacceptable or already taken.");
+                    from.SendMessage(0X22, "Ese nombre no es aceptable o ya está en uso.");
                 }
             }
             else
             {
-                from.SendMessage(0X22, "You must enter a name.");
+                from.SendMessage(0X22, "Debes introducir un nombre.");
             }
 
             from.SendGump(new NameAlterGump(from));

--- a/Scripts/Server Functions/Unique Name/NameChangeGump.cs
+++ b/Scripts/Server Functions/Unique Name/NameChangeGump.cs
@@ -9,7 +9,7 @@ namespace Server.Gumps
 {
     public class NameChangeGump : Gump
     {
-        const string DEFAULT_NAME = "Type here...";
+        const string DEFAULT_NAME = "Escribe aquí...";
         public NameChangeGump(Mobile from) : base(100, 100)
         {
             // Immobilize the player
@@ -24,9 +24,9 @@ namespace Server.Gumps
 
             AddBackground(137, 119, 334, 195, 9250);
             AddBackground(221, 264, 171, 29, 3000);
-            AddHtml(153, 135, 304, 113, @"The name you've chosen is currently in use and is no longer available. You must choose a different name before you're able to continue. So delete the text below and enter a new fantasy appropriate name.", (bool)true, (bool)false);
+            AddHtml(153, 135, 304, 113, @"El nombre que has elegido ya está en uso y no se encuentra disponible. Debes elegir otro nombre para continuar. Borra el texto de abajo e introduce un nuevo nombre de fantasía.", (bool)true, (bool)false);
 
-            AddLabel(153, 270, 0, @"New Name:");
+            AddLabel(153, 270, 0, @"Nuevo nombre:");
             AddTextEntry(224, 268, 163, 21, 0, 1, DEFAULT_NAME, 16); // 16 Character Limit
             AddButton(395, 267, 4023, 4024, 1, GumpButtonType.Reply, 0); // Okay
         }
@@ -51,13 +51,13 @@ namespace Server.Gumps
             {
                 if (!NameVerification.Validate(name, 2, 16, true, false, true, 1, NameVerification.SpaceOnly))
                 {
-                    from.SendMessage(0X22, "That name is unacceptable or already taken.");
+                    from.SendMessage(0X22, "Ese nombre no es aceptable o ya está en uso.");
                     from.SendGump(new NameChangeGump(from));
                     return;
                 }
                 if (CharacterCreation.CheckDupe(from, name))
                 {
-                    from.SendMessage(0X22, "Your name is now {0}.", name);
+                    from.SendMessage(0X22, "Tu nombre ahora es {0}.", name);
                     from.Name = name;
                     from.CantWalk = false;
                     return;
@@ -65,7 +65,7 @@ namespace Server.Gumps
             }
             else
             {
-                from.SendMessage(0X22, "You must enter a name.");
+                from.SendMessage(0X22, "Debes introducir un nombre.");
             }
 
             from.SendGump(new NameChangeGump(from));


### PR DESCRIPTION
## Summary
- Reemplaza el texto por defecto de los campos de nombre con "Escribe aquí..."
- Traduce la etiqueta de cambio de nombre a "Nuevo nombre:"
- Localiza mensajes de validación y el texto de ayuda de cambio de nombre al español

## Testing
- `dotnet build Server/Server.csproj`
- `dotnet build Scripts/Scripts.csproj` *(errored: Unexpected character '\0')*


------
https://chatgpt.com/codex/tasks/task_e_68aa552c23b0832eb908309faba62468